### PR TITLE
feat: Add SSH self-setup and key management for mcp_admin user

### DIFF
--- a/src/homelab_mcp/server.py
+++ b/src/homelab_mcp/server.py
@@ -9,6 +9,7 @@ import sys
 from typing import Any, Dict, Optional
 
 from .tools import get_available_tools, execute_tool
+from .ssh_tools import ensure_mcp_ssh_key
 
 
 class HomelabMCPServer:
@@ -16,6 +17,7 @@ class HomelabMCPServer:
     
     def __init__(self):
         self.tools = get_available_tools()
+        self.ssh_key_initialized = False
     
     async def handle_request(self, request: Dict[str, Any]) -> Dict[str, Any]:
         """Handle incoming MCP requests."""
@@ -25,6 +27,11 @@ class HomelabMCPServer:
         
         try:
             if method == "initialize":
+                # Initialize SSH key on first request
+                if not self.ssh_key_initialized:
+                    await ensure_mcp_ssh_key()
+                    self.ssh_key_initialized = True
+                
                 return self._success_response(request_id, {
                     "protocolVersion": "2024-11-05",
                     "capabilities": {

--- a/src/homelab_mcp/ssh_tools.py
+++ b/src/homelab_mcp/ssh_tools.py
@@ -2,8 +2,249 @@
 
 import asyncio
 import json
+import os
+import getpass
+from pathlib import Path
 from typing import Dict, Any, Optional, cast
 import asyncssh
+
+
+def get_mcp_ssh_key_path() -> Path:
+    """Get the path to the MCP SSH key."""
+    home_dir = Path.home()
+    ssh_dir = home_dir / '.ssh'
+    return ssh_dir / 'mcp_admin_rsa'
+
+
+def get_mcp_public_key_path() -> Path:
+    """Get the path to the MCP SSH public key."""
+    return get_mcp_ssh_key_path().with_suffix('.pub')
+
+
+async def ensure_mcp_ssh_key() -> str:
+    """Ensure MCP has its own SSH key, generate if missing."""
+    key_path = get_mcp_ssh_key_path()
+    pub_key_path = get_mcp_public_key_path()
+    
+    # Check if key already exists
+    if key_path.exists() and pub_key_path.exists():
+        return str(key_path)
+    
+    # Create .ssh directory if it doesn't exist
+    ssh_dir = key_path.parent
+    ssh_dir.mkdir(mode=0o700, exist_ok=True)
+    
+    # Generate SSH key pair
+    private_key = asyncssh.generate_private_key('ssh-rsa', key_size=2048)
+    public_key = private_key.export_public_key()
+    
+    # Write private key
+    with open(key_path, 'wb') as f:
+        f.write(private_key.export_private_key())
+    key_path.chmod(0o600)
+    
+    # Write public key with mcp_admin comment
+    with open(pub_key_path, 'w') as f:
+        f.write(f"{public_key.decode()} mcp_admin@{os.uname().nodename}\n")
+    pub_key_path.chmod(0o644)
+    
+    return str(key_path)
+
+
+async def setup_remote_mcp_admin(
+    hostname: str,
+    username: str, 
+    password: str,
+    force_update_key: bool = True
+) -> str:
+    """SSH into remote system and setup mcp_admin user with admin permissions."""
+    try:
+        # Ensure we have our SSH key
+        key_path = await ensure_mcp_ssh_key()
+        pub_key_path = get_mcp_public_key_path()
+        
+        if not pub_key_path.exists():
+            raise ValueError("MCP public key not found")
+        
+        # Read our public key
+        with open(pub_key_path, 'r') as f:
+            public_key = f.read().strip()
+        
+        # Connect to remote system
+        connect_kwargs = {
+            "host": hostname,
+            "username": username,
+            "password": password,
+            "known_hosts": None,
+            "connect_timeout": 10
+        }
+        
+        async with await asyncssh.connect(**connect_kwargs) as conn:
+            setup_results = {}
+            
+            # Check if mcp_admin user already exists
+            user_check = await conn.run('id mcp_admin', check=False)
+            user_exists = user_check.exit_status == 0
+            
+            if not user_exists:
+                # Create mcp_admin user
+                create_user = await conn.run(
+                    'sudo useradd -m -s /bin/bash -G sudo mcp_admin', 
+                    check=False
+                )
+                if create_user.exit_status != 0:
+                    setup_results['user_creation'] = f"Failed: {create_user.stderr}"
+                else:
+                    setup_results['user_creation'] = "Success: mcp_admin user created"
+            else:
+                setup_results['user_creation'] = "User already exists"
+            
+            # Ensure mcp_admin is in sudo group
+            sudo_group = await conn.run('sudo usermod -a -G sudo mcp_admin', check=False)
+            if sudo_group.exit_status == 0:
+                setup_results['sudo_access'] = "Success: Added to sudo group"
+            else:
+                setup_results['sudo_access'] = f"Failed: {sudo_group.stderr}"
+            
+            # Check if our key is already in authorized_keys
+            key_check = await conn.run(
+                f'sudo grep -F "{public_key}" /home/mcp_admin/.ssh/authorized_keys 2>/dev/null',
+                check=False
+            )
+            
+            key_exists = key_check.exit_status == 0
+            
+            if key_exists and not force_update_key:
+                setup_results['ssh_key'] = "SSH key already exists"
+            else:
+                # Setup SSH directory
+                mkdir_cmd = await conn.run(
+                    'sudo -u mcp_admin mkdir -p /home/mcp_admin/.ssh && '
+                    'sudo -u mcp_admin chmod 700 /home/mcp_admin/.ssh',
+                    check=False
+                )
+                
+                if mkdir_cmd.exit_status != 0:
+                    setup_results['ssh_key'] = f"Failed to create .ssh directory: {mkdir_cmd.stderr}"
+                else:
+                    if force_update_key and key_exists:
+                        # Remove old MCP keys (those with mcp_admin@ comment)
+                        await conn.run(
+                            'sudo grep -v "mcp_admin@" /home/mcp_admin/.ssh/authorized_keys | '
+                            'sudo -u mcp_admin tee /home/mcp_admin/.ssh/authorized_keys.tmp && '
+                            'sudo -u mcp_admin mv /home/mcp_admin/.ssh/authorized_keys.tmp /home/mcp_admin/.ssh/authorized_keys',
+                            check=False
+                        )
+                        
+                    # Add new key
+                    add_key = await conn.run(
+                        f'echo "{public_key}" | sudo -u mcp_admin tee -a /home/mcp_admin/.ssh/authorized_keys && '
+                        'sudo -u mcp_admin chmod 600 /home/mcp_admin/.ssh/authorized_keys',
+                        check=False
+                    )
+                    
+                    if add_key.exit_status == 0:
+                        if key_exists and force_update_key:
+                            setup_results['ssh_key'] = "Success: SSH key updated"
+                        else:
+                            setup_results['ssh_key'] = "Success: SSH key installed"
+                    else:
+                        setup_results['ssh_key'] = f"Failed: {add_key.stderr}"
+            
+            # Enable passwordless sudo for mcp_admin
+            sudoers_setup = await conn.run(
+                'echo "mcp_admin ALL=(ALL) NOPASSWD:ALL" | sudo tee /etc/sudoers.d/mcp_admin',
+                check=False
+            )
+            
+            if sudoers_setup.exit_status == 0:
+                setup_results['passwordless_sudo'] = "Success: Passwordless sudo enabled"
+            else:
+                setup_results['passwordless_sudo'] = f"Failed: {sudoers_setup.stderr}"
+            
+            # Test SSH key authentication
+            test_conn = await conn.run('sudo -u mcp_admin whoami', check=False)
+            if test_conn.exit_status == 0:
+                setup_results['test_access'] = "Success: mcp_admin access verified"
+            else:
+                setup_results['test_access'] = f"Failed: {test_conn.stderr}"
+        
+        return json.dumps({
+            "status": "success",
+            "hostname": hostname,
+            "mcp_admin_setup": setup_results,
+            "ssh_key_path": key_path,
+            "public_key": public_key
+        }, indent=2)
+        
+    except Exception as e:
+        return json.dumps({
+            "status": "error",
+            "hostname": hostname,
+            "error": str(e)
+        }, indent=2)
+
+
+async def verify_mcp_admin_access(hostname: str) -> str:
+    """Verify SSH key access to mcp_admin account on remote system."""
+    try:
+        key_path = get_mcp_ssh_key_path()
+        
+        if not key_path.exists():
+            return json.dumps({
+                "status": "error",
+                "hostname": hostname,
+                "error": "MCP SSH key not found. Run ensure_mcp_ssh_key() first."
+            }, indent=2)
+        
+        # Test SSH connection with key
+        connect_kwargs = {
+            "host": hostname,
+            "username": "mcp_admin",
+            "client_keys": [str(key_path)],
+            "known_hosts": None,
+            "connect_timeout": 10
+        }
+        
+        async with await asyncssh.connect(**connect_kwargs) as conn:
+            # Test basic access
+            whoami_result = await conn.run('whoami', check=False)
+            if whoami_result.exit_status != 0:
+                raise Exception("Failed to execute whoami command")
+            
+            # Test sudo access
+            sudo_result = await conn.run('sudo -n whoami', check=False)
+            sudo_access = sudo_result.exit_status == 0
+            
+            # Get system hostname
+            hostname_result = await conn.run('hostname', check=False)
+            remote_hostname = hostname
+            if hostname_result.exit_status == 0 and hostname_result.stdout:
+                remote_hostname = cast(str, hostname_result.stdout).strip()
+            
+            return json.dumps({
+                "status": "success",
+                "hostname": remote_hostname,
+                "connection_ip": hostname,
+                "mcp_admin": {
+                    "ssh_access": "Success: Connected with SSH key",
+                    "sudo_access": "Success: Passwordless sudo working" if sudo_access else "Failed: No sudo access",
+                    "username": cast(str, whoami_result.stdout).strip() if whoami_result.stdout else "unknown"
+                }
+            }, indent=2)
+        
+    except asyncssh.misc.PermissionDenied:
+        return json.dumps({
+            "status": "error",
+            "hostname": hostname,
+            "error": "SSH key authentication failed for mcp_admin"
+        }, indent=2)
+    except Exception as e:
+        return json.dumps({
+            "status": "error",
+            "hostname": hostname,
+            "error": str(e)
+        }, indent=2)
 
 
 async def ssh_discover_system(
@@ -26,6 +267,13 @@ async def ssh_discover_system(
             connect_kwargs["client_keys"] = [key_path]
         elif password:
             connect_kwargs["password"] = password
+        elif username == "mcp_admin":
+            # Use MCP key for mcp_admin user if available
+            mcp_key_path = get_mcp_ssh_key_path()
+            if mcp_key_path.exists():
+                connect_kwargs["client_keys"] = [str(mcp_key_path)]
+            else:
+                raise ValueError("MCP SSH key not found and no password provided for mcp_admin")
         else:
             raise ValueError("Either password or key_path must be provided")
         

--- a/src/homelab_mcp/tools.py
+++ b/src/homelab_mcp/tools.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict
 
-from .ssh_tools import ssh_discover_system
+from .ssh_tools import ssh_discover_system, setup_remote_mcp_admin, verify_mcp_admin_access
 
 
 # Tool registry
@@ -26,11 +26,11 @@ TOOLS = {
                 },
                 "username": {
                     "type": "string", 
-                    "description": "SSH username"
+                    "description": "SSH username (use 'mcp_admin' for passwordless access after setup)"
                 },
                 "password": {
                     "type": "string",
-                    "description": "SSH password (if not using key)"
+                    "description": "SSH password (not needed for mcp_admin after setup)"
                 },
                 "key_path": {
                     "type": "string",
@@ -38,6 +38,45 @@ TOOLS = {
                 }
             },
             "required": ["hostname", "username"]
+        }
+    },
+    "setup_mcp_admin": {
+        "description": "SSH into a remote system and setup mcp_admin user with admin permissions and SSH key access",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "hostname": {
+                    "type": "string",
+                    "description": "Hostname or IP address of the target system"
+                },
+                "username": {
+                    "type": "string",
+                    "description": "Admin username to connect with (must have sudo access)"
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for the admin user"
+                },
+                "force_update_key": {
+                    "type": "boolean",
+                    "description": "Force update SSH key even if mcp_admin already has keys (default: true)",
+                    "default": True
+                }
+            },
+            "required": ["hostname", "username", "password"]
+        }
+    },
+    "verify_mcp_admin": {
+        "description": "Verify SSH key access to mcp_admin account on a remote system",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "hostname": {
+                    "type": "string",
+                    "description": "Hostname or IP address of the target system"
+                }
+            },
+            "required": ["hostname"]
         }
     }
 }
@@ -55,6 +94,14 @@ async def execute_tool(tool_name: str, arguments: Dict[str, Any]) -> Dict[str, A
     
     elif tool_name == "ssh_discover":
         result = await ssh_discover_system(**arguments)
+        return {"content": [{"type": "text", "text": result}]}
+    
+    elif tool_name == "setup_mcp_admin":
+        result = await setup_remote_mcp_admin(**arguments)
+        return {"content": [{"type": "text", "text": result}]}
+    
+    elif tool_name == "verify_mcp_admin":
+        result = await verify_mcp_admin_access(**arguments)
         return {"content": [{"type": "text", "text": result}]}
     
     else:

--- a/tests/test_ssh_tools.py
+++ b/tests/test_ssh_tools.py
@@ -4,7 +4,14 @@ import json
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 import asyncssh
-from src.homelab_mcp.ssh_tools import ssh_discover_system
+from src.homelab_mcp.ssh_tools import (
+    ssh_discover_system,
+    ensure_mcp_ssh_key,
+    setup_remote_mcp_admin,
+    verify_mcp_admin_access,
+    get_mcp_ssh_key_path,
+    get_mcp_public_key_path
+)
 
 
 @pytest.mark.asyncio
@@ -196,3 +203,460 @@ async def test_ssh_discover_with_key_path(mock_connect):
     call_args = mock_connect.call_args[1]
     assert call_args["client_keys"] == ["/path/to/key"]
     assert "password" not in call_args
+
+
+@pytest.mark.asyncio
+@patch('src.homelab_mcp.ssh_tools.Path.exists')
+@patch('src.homelab_mcp.ssh_tools.Path.mkdir')
+@patch('src.homelab_mcp.ssh_tools.Path.chmod')
+@patch('builtins.open', create=True)
+@patch('src.homelab_mcp.ssh_tools.asyncssh.generate_private_key')
+async def test_ensure_mcp_ssh_key_creates_new(mock_generate, mock_open, mock_chmod, mock_mkdir, mock_exists):
+    """Test SSH key generation when keys don't exist."""
+    # Mock that keys don't exist
+    mock_exists.return_value = False
+    
+    # Mock key generation
+    mock_private_key = MagicMock()
+    mock_private_key.export_private_key.return_value = b'private_key_data'
+    mock_private_key.export_public_key.return_value = b'public_key_data'
+    mock_generate.return_value = mock_private_key
+    
+    # Mock file operations
+    mock_file = MagicMock()
+    mock_open.return_value.__enter__.return_value = mock_file
+    
+    # Execute
+    result = await ensure_mcp_ssh_key()
+    
+    # Verify key generation
+    mock_generate.assert_called_once_with('ssh-rsa', key_size=2048)
+    
+    # Verify directory creation
+    mock_mkdir.assert_called_once_with(mode=0o700, exist_ok=True)
+    
+    # Verify file writes
+    assert mock_open.call_count == 2
+    assert mock_chmod.call_count == 2
+    
+    # Verify result
+    assert str(get_mcp_ssh_key_path()) in result
+
+
+@pytest.mark.asyncio
+@patch('src.homelab_mcp.ssh_tools.Path.exists')
+async def test_ensure_mcp_ssh_key_uses_existing(mock_exists):
+    """Test that existing SSH keys are reused."""
+    # Mock that keys exist
+    mock_exists.return_value = True
+    
+    # Execute
+    result = await ensure_mcp_ssh_key()
+    
+    # Verify result points to existing key
+    assert str(get_mcp_ssh_key_path()) in result
+
+
+@pytest.mark.asyncio
+@patch('src.homelab_mcp.ssh_tools.ensure_mcp_ssh_key')
+@patch('src.homelab_mcp.ssh_tools.get_mcp_public_key_path')
+@patch('builtins.open', create=True)
+@patch('src.homelab_mcp.ssh_tools.asyncssh.connect')
+async def test_setup_remote_mcp_admin_success(mock_connect, mock_open, mock_pub_key_path, mock_ensure_key):
+    """Test successful remote mcp_admin setup."""
+    # Mock SSH key
+    mock_ensure_key.return_value = "/home/user/.ssh/mcp_admin_rsa"
+    mock_pub_key_path.return_value.exists.return_value = True
+    
+    # Mock public key read
+    mock_file = MagicMock()
+    mock_file.read.return_value = "ssh-rsa AAAAB3... mcp_admin@host"
+    mock_open.return_value.__enter__.return_value = mock_file
+    
+    # Mock SSH connection and commands
+    mock_conn = AsyncMock()
+    
+    # Mock command results
+    user_check = MagicMock()
+    user_check.exit_status = 1  # User doesn't exist
+    
+    create_user = MagicMock()
+    create_user.exit_status = 0
+    
+    sudo_group = MagicMock()
+    sudo_group.exit_status = 0
+    
+    key_check = MagicMock()
+    key_check.exit_status = 1  # Key doesn't exist
+    
+    mkdir_cmd = MagicMock()
+    mkdir_cmd.exit_status = 0
+    
+    add_key = MagicMock()
+    add_key.exit_status = 0
+    
+    sudoers_setup = MagicMock()
+    sudoers_setup.exit_status = 0
+    
+    test_conn = MagicMock()
+    test_conn.exit_status = 0
+    
+    mock_conn.run.side_effect = [user_check, create_user, sudo_group, key_check, mkdir_cmd, add_key, sudoers_setup, test_conn]
+    
+    # Setup context manager
+    async def mock_context_mgr():
+        class MockContext:
+            async def __aenter__(self):
+                return mock_conn
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                return None
+        return MockContext()
+    
+    # Make connect return the async context manager
+    mock_connect.side_effect = lambda **kwargs: mock_context_mgr()
+    
+    # Execute
+    result = await setup_remote_mcp_admin("test-host", "admin", "password")
+    
+    # Parse result
+    result_data = json.loads(result)
+    
+    # Verify success
+    assert result_data["status"] == "success"
+    assert result_data["hostname"] == "test-host"
+    assert "mcp_admin_setup" in result_data
+    assert result_data["mcp_admin_setup"]["user_creation"] == "Success: mcp_admin user created"
+    assert result_data["mcp_admin_setup"]["sudo_access"] == "Success: Added to sudo group"
+    assert result_data["mcp_admin_setup"]["ssh_key"] == "Success: SSH key installed"
+    assert result_data["mcp_admin_setup"]["passwordless_sudo"] == "Success: Passwordless sudo enabled"
+    assert result_data["mcp_admin_setup"]["test_access"] == "Success: mcp_admin access verified"
+
+
+@pytest.mark.asyncio
+@patch('src.homelab_mcp.ssh_tools.ensure_mcp_ssh_key')
+@patch('src.homelab_mcp.ssh_tools.get_mcp_public_key_path')
+@patch('builtins.open', create=True)
+@patch('src.homelab_mcp.ssh_tools.asyncssh.connect')
+async def test_setup_remote_mcp_admin_user_exists(mock_connect, mock_open, mock_pub_key_path, mock_ensure_key):
+    """Test remote mcp_admin setup when user already exists."""
+    # Mock SSH key
+    mock_ensure_key.return_value = "/home/user/.ssh/mcp_admin_rsa"
+    mock_pub_key_path.return_value.exists.return_value = True
+    
+    # Mock public key read
+    mock_file = MagicMock()
+    mock_file.read.return_value = "ssh-rsa AAAAB3... mcp_admin@host"
+    mock_open.return_value.__enter__.return_value = mock_file
+    
+    # Mock SSH connection and commands
+    mock_conn = AsyncMock()
+    
+    # Mock command results
+    user_check = MagicMock()
+    user_check.exit_status = 0  # User exists
+    
+    sudo_group = MagicMock()
+    sudo_group.exit_status = 0
+    
+    ssh_setup = MagicMock()
+    ssh_setup.exit_status = 0
+    
+    sudoers_setup = MagicMock()
+    sudoers_setup.exit_status = 0
+    
+    test_conn = MagicMock()
+    test_conn.exit_status = 0
+    
+    key_check = MagicMock()
+    key_check.exit_status = 1  # Key doesn't exist
+    
+    mkdir_cmd = MagicMock()
+    mkdir_cmd.exit_status = 0
+    
+    add_key = MagicMock()
+    add_key.exit_status = 0
+    
+    mock_conn.run.side_effect = [user_check, sudo_group, key_check, mkdir_cmd, add_key, sudoers_setup, test_conn]
+    
+    # Setup context manager
+    async def mock_context_mgr():
+        class MockContext:
+            async def __aenter__(self):
+                return mock_conn
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                return None
+        return MockContext()
+    
+    # Make connect return the async context manager
+    mock_connect.side_effect = lambda **kwargs: mock_context_mgr()
+    
+    # Execute
+    result = await setup_remote_mcp_admin("test-host", "admin", "password")
+    
+    # Parse result
+    result_data = json.loads(result)
+    
+    # Verify success
+    assert result_data["status"] == "success"
+    assert result_data["mcp_admin_setup"]["user_creation"] == "User already exists"
+
+
+@pytest.mark.asyncio
+@patch('src.homelab_mcp.ssh_tools.get_mcp_ssh_key_path')
+@patch('src.homelab_mcp.ssh_tools.asyncssh.connect')
+async def test_verify_mcp_admin_access_success(mock_connect, mock_key_path):
+    """Test successful mcp_admin access verification."""
+    # Mock SSH key exists
+    mock_key_path.return_value.exists.return_value = True
+    
+    # Mock SSH connection and commands
+    mock_conn = AsyncMock()
+    
+    # Mock command results
+    whoami_result = MagicMock()
+    whoami_result.exit_status = 0
+    whoami_result.stdout = "mcp_admin"
+    
+    sudo_result = MagicMock()
+    sudo_result.exit_status = 0
+    
+    hostname_result = MagicMock()
+    hostname_result.exit_status = 0
+    hostname_result.stdout = "test-server"
+    
+    mock_conn.run.side_effect = [whoami_result, sudo_result, hostname_result]
+    
+    # Setup context manager
+    async def mock_context_mgr():
+        class MockContext:
+            async def __aenter__(self):
+                return mock_conn
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                return None
+        return MockContext()
+    
+    # Make connect return the async context manager
+    mock_connect.side_effect = lambda **kwargs: mock_context_mgr()
+    
+    # Execute
+    result = await verify_mcp_admin_access("test-host")
+    
+    # Parse result
+    result_data = json.loads(result)
+    
+    # Verify success
+    assert result_data["status"] == "success"
+    assert result_data["hostname"] == "test-server"
+    assert result_data["connection_ip"] == "test-host"
+    assert result_data["mcp_admin"]["ssh_access"] == "Success: Connected with SSH key"
+    assert result_data["mcp_admin"]["sudo_access"] == "Success: Passwordless sudo working"
+    assert result_data["mcp_admin"]["username"] == "mcp_admin"
+
+
+@pytest.mark.asyncio
+@patch('src.homelab_mcp.ssh_tools.get_mcp_ssh_key_path')
+async def test_verify_mcp_admin_access_no_key(mock_key_path):
+    """Test verification when SSH key doesn't exist."""
+    # Mock SSH key doesn't exist
+    mock_key_path.return_value.exists.return_value = False
+    
+    # Execute
+    result = await verify_mcp_admin_access("test-host")
+    
+    # Parse result
+    result_data = json.loads(result)
+    
+    # Verify error
+    assert result_data["status"] == "error"
+    assert "SSH key not found" in result_data["error"]
+
+
+@pytest.mark.asyncio
+@patch('src.homelab_mcp.ssh_tools.get_mcp_ssh_key_path')
+@patch('src.homelab_mcp.ssh_tools.asyncssh.connect')
+async def test_verify_mcp_admin_access_auth_failure(mock_connect, mock_key_path):
+    """Test verification with authentication failure."""
+    # Mock SSH key exists
+    mock_key_path.return_value.exists.return_value = True
+    
+    # Mock connection failure
+    mock_connect.side_effect = asyncssh.misc.PermissionDenied("Authentication failed")
+    
+    # Execute
+    result = await verify_mcp_admin_access("test-host")
+    
+    # Parse result
+    result_data = json.loads(result)
+    
+    # Verify error
+    assert result_data["status"] == "error"
+    assert "SSH key authentication failed" in result_data["error"]
+
+
+@pytest.mark.asyncio
+@patch('src.homelab_mcp.ssh_tools.get_mcp_ssh_key_path')
+@patch('src.homelab_mcp.ssh_tools.asyncssh.connect')
+async def test_ssh_discover_with_mcp_admin_auto_key(mock_connect, mock_key_path):
+    """Test SSH discovery auto-uses MCP key for mcp_admin user."""
+    # Mock SSH key exists
+    mock_key_path.return_value.exists.return_value = True
+    mock_key_path.return_value.__str__.return_value = "/home/user/.ssh/mcp_admin_rsa"
+    
+    # Mock SSH connection
+    mock_conn = AsyncMock()
+    mock_context = AsyncMock()
+    mock_context.__aenter__.return_value = mock_conn
+    mock_context.__aexit__.return_value = None
+    mock_connect.return_value = mock_context
+    
+    # Mock minimal command results
+    mock_result = MagicMock()
+    mock_result.exit_status = 1  # Commands fail
+    mock_result.stdout = None
+    mock_conn.run.return_value = mock_result
+    
+    # Execute discovery as mcp_admin without password
+    result = await ssh_discover_system(
+        hostname="test-host",
+        username="mcp_admin"
+    )
+    
+    # Verify result is valid JSON
+    result_data = json.loads(result)
+    assert "status" in result_data
+    
+    # Verify connect was called with MCP key
+    mock_connect.assert_called_once()
+    call_args = mock_connect.call_args[1]
+    assert call_args["client_keys"] == ["/home/user/.ssh/mcp_admin_rsa"]
+    assert "password" not in call_args
+
+
+@pytest.mark.asyncio
+@patch('src.homelab_mcp.ssh_tools.ensure_mcp_ssh_key')
+@patch('src.homelab_mcp.ssh_tools.get_mcp_public_key_path')
+@patch('builtins.open', create=True)
+@patch('src.homelab_mcp.ssh_tools.asyncssh.connect')
+async def test_setup_remote_mcp_admin_force_update_key(mock_connect, mock_open, mock_pub_key_path, mock_ensure_key):
+    """Test remote mcp_admin setup with force key update."""
+    # Mock SSH key
+    mock_ensure_key.return_value = "/home/user/.ssh/mcp_admin_rsa"
+    mock_pub_key_path.return_value.exists.return_value = True
+    
+    # Mock public key read
+    mock_file = MagicMock()
+    mock_file.read.return_value = "ssh-rsa AAAAB3NEW... mcp_admin@host"
+    mock_open.return_value.__enter__.return_value = mock_file
+    
+    # Mock SSH connection and commands
+    mock_conn = AsyncMock()
+    
+    # Mock command results
+    user_check = MagicMock()
+    user_check.exit_status = 0  # User exists
+    
+    sudo_group = MagicMock()
+    sudo_group.exit_status = 0
+    
+    key_check = MagicMock()
+    key_check.exit_status = 0  # Key exists (but different)
+    
+    mkdir_cmd = MagicMock()
+    mkdir_cmd.exit_status = 0
+    
+    remove_old = MagicMock()
+    remove_old.exit_status = 0
+    
+    add_key = MagicMock()
+    add_key.exit_status = 0
+    
+    sudoers_setup = MagicMock()
+    sudoers_setup.exit_status = 0
+    
+    test_conn = MagicMock()
+    test_conn.exit_status = 0
+    
+    mock_conn.run.side_effect = [user_check, sudo_group, key_check, mkdir_cmd, remove_old, add_key, sudoers_setup, test_conn]
+    
+    # Setup context manager
+    async def mock_context_mgr():
+        class MockContext:
+            async def __aenter__(self):
+                return mock_conn
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                return None
+        return MockContext()
+    
+    # Make connect return the async context manager
+    mock_connect.side_effect = lambda **kwargs: mock_context_mgr()
+    
+    # Execute with force_update_key=True (default)
+    result = await setup_remote_mcp_admin("test-host", "admin", "password")
+    
+    # Parse result
+    result_data = json.loads(result)
+    
+    # Verify success
+    assert result_data["status"] == "success"
+    assert result_data["mcp_admin_setup"]["user_creation"] == "User already exists"
+    assert result_data["mcp_admin_setup"]["ssh_key"] == "Success: SSH key updated"
+
+
+@pytest.mark.asyncio
+@patch('src.homelab_mcp.ssh_tools.ensure_mcp_ssh_key')
+@patch('src.homelab_mcp.ssh_tools.get_mcp_public_key_path')
+@patch('builtins.open', create=True)
+@patch('src.homelab_mcp.ssh_tools.asyncssh.connect')
+async def test_setup_remote_mcp_admin_no_force_update(mock_connect, mock_open, mock_pub_key_path, mock_ensure_key):
+    """Test remote mcp_admin setup without forcing key update."""
+    # Mock SSH key
+    mock_ensure_key.return_value = "/home/user/.ssh/mcp_admin_rsa"
+    mock_pub_key_path.return_value.exists.return_value = True
+    
+    # Mock public key read
+    mock_file = MagicMock()
+    mock_file.read.return_value = "ssh-rsa AAAAB3... mcp_admin@host"
+    mock_open.return_value.__enter__.return_value = mock_file
+    
+    # Mock SSH connection and commands
+    mock_conn = AsyncMock()
+    
+    # Mock command results
+    user_check = MagicMock()
+    user_check.exit_status = 0  # User exists
+    
+    sudo_group = MagicMock()
+    sudo_group.exit_status = 0
+    
+    key_check = MagicMock()
+    key_check.exit_status = 0  # Key already exists
+    
+    sudoers_setup = MagicMock()
+    sudoers_setup.exit_status = 0
+    
+    test_conn = MagicMock()
+    test_conn.exit_status = 0
+    
+    mock_conn.run.side_effect = [user_check, sudo_group, key_check, sudoers_setup, test_conn]
+    
+    # Setup context manager
+    async def mock_context_mgr():
+        class MockContext:
+            async def __aenter__(self):
+                return mock_conn
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                return None
+        return MockContext()
+    
+    # Make connect return the async context manager
+    mock_connect.side_effect = lambda **kwargs: mock_context_mgr()
+    
+    # Execute with force_update_key=False
+    result = await setup_remote_mcp_admin("test-host", "admin", "password", force_update_key=False)
+    
+    # Parse result
+    result_data = json.loads(result)
+    
+    # Verify success
+    assert result_data["status"] == "success"
+    assert result_data["mcp_admin_setup"]["ssh_key"] == "SSH key already exists"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -10,9 +10,11 @@ def test_get_available_tools():
     """Test getting available tools."""
     tools = get_available_tools()
     
-    assert len(tools) == 2
+    assert len(tools) == 4
     assert "hello_world" in tools
     assert "ssh_discover" in tools
+    assert "setup_mcp_admin" in tools
+    assert "verify_mcp_admin" in tools
     
     # Check hello_world tool schema
     hello_tool = tools["hello_world"]


### PR DESCRIPTION
- Auto-generate SSH keys on server startup (~/.ssh/mcp_admin_rsa)
- Add setup_mcp_admin tool to configure remote systems with:
  - User creation with sudo privileges
  - SSH key authentication setup
  - Passwordless sudo access
- Add verify_mcp_admin tool to test SSH key access
- Add force_update_key parameter for handling existing users
- Update ssh_discover to auto-use MCP keys for mcp_admin
- Comprehensive test coverage for all new functionality
- Updated documentation with examples and workflows

🤖 Generated with [Claude Code](https://claude.ai/code)