### PR TITLE
fix: Resolve JSON import scope error and cleanup test functions

### DIFF
--- a/src/homelab_mcp/tools.py
+++ b/src/homelab_mcp/tools.py
@@ -915,7 +915,6 @@ async def execute_tool(tool_name: str, arguments: Dict[str, Any]) -> Dict[str, A
         return {"content": [{"type": "text", "text": result}]}
     
     elif tool_name == "get_network_sitemap":
-        import json
         devices = sitemap.get_all_devices()
         result = json.dumps({
             "status": "success",
@@ -925,7 +924,6 @@ async def execute_tool(tool_name: str, arguments: Dict[str, Any]) -> Dict[str, A
         return {"content": [{"type": "text", "text": result}]}
     
     elif tool_name == "analyze_network_topology":
-        import json
         analysis = sitemap.analyze_network_topology()
         result = json.dumps({
             "status": "success",
@@ -934,7 +932,6 @@ async def execute_tool(tool_name: str, arguments: Dict[str, Any]) -> Dict[str, A
         return {"content": [{"type": "text", "text": result}]}
     
     elif tool_name == "suggest_deployments":
-        import json
         suggestions = sitemap.suggest_deployments()
         result = json.dumps({
             "status": "success",
@@ -943,7 +940,6 @@ async def execute_tool(tool_name: str, arguments: Dict[str, Any]) -> Dict[str, A
         return {"content": [{"type": "text", "text": result}]}
     
     elif tool_name == "get_device_changes":
-        import json
         changes = sitemap.get_device_changes(
             arguments["device_id"],
             arguments.get("limit", 10)


### PR DESCRIPTION
## Summary
- Fix MCP error -32603: \"cannot access local variable 'json' where it is not associated with a value\"
- Remove hello_world test function that was only needed for initial deployment testing
- Update tool count from 33 to 32 tools in documentation

## Bug Fix: JSON Import Scope Error

### Problem
Claude was encountering `MCP error -32603` when calling certain tools due to variable scope conflicts with JSON imports.

### Root Cause
Redundant local `import json` statements inside function blocks were conflicting with the global `import json` at the top of the file.

### Solution
- Removed unnecessary local `import json` statements in:
  - `get_network_sitemap`
  - `analyze_network_topology` 
  - `suggest_deployments`
  - `get_device_changes`
- JSON module was already imported globally, so local imports were redundant

## Cleanup: Remove Test Function

### Changes
- Remove `hello_world` tool definition and execution logic
- Update README documentation to reflect 32 tools instead of 33
- Remove hello_world examples from documentation
- Clean up test function that served its purpose during development

## Test Results
✅ **Server startup**: Successfully loads all 32 tools  
✅ **Tool listing**: `tools/list` returns complete tool registry  
✅ **JSON serialization**: All tools that use JSON work correctly  
✅ **No scope errors**: Fixed variable scope conflict

## Files Changed
- `src/homelab_mcp/tools.py` - Remove redundant imports and hello_world
- `README.md` - Update tool count and remove hello_world references

🤖 Generated with [Claude Code](https://claude.ai/code)